### PR TITLE
show array attributes like extras

### DIFF
--- a/resources/views/columns/activity_changes.blade.php
+++ b/resources/views/columns/activity_changes.blade.php
@@ -29,7 +29,7 @@ $old = isset($values['old']);
             @endif
         </td>
         @endif
-        <td class="{{ ($values['old'][$key] != $new) ? 'text-success' : '' }}">
+        <td class="{{ (isset($values['old']) && $values['old'][$key] != $new) ? 'text-success' : '' }}">
             @if (is_array($new))
             <ul class="pl-3" style="list-style: circle">
                 @foreach ($new as $attribute => $value)

--- a/resources/views/columns/activity_changes.blade.php
+++ b/resources/views/columns/activity_changes.blade.php
@@ -15,9 +15,19 @@ $old = isset($values['old']);
     @foreach(($values['attributes'] ?? []) as $key => $new)
     @if(!in_array($key, ['id', 'deleted_at']))
     <tr>
-        <td>{{ str_replace('_', ' ', ucfirst(__($key))) }}</td>
+        <td class="font-weight-bold">{{ str_replace('_', ' ', ucfirst(__($key))) }}</td>
         @if($old)
-        <td>{{ $values['old'][$key] }}</td>
+        <td>
+            @if (is_array($values['old'][$key]))
+                <ul class="pl-1" style="list-style: circle">
+                @foreach ($values['old'][$key] as $attribute => $value)
+                    <li><strong>{{ $attribute }}</strong>: {{ $value }}</li>
+                @endforeach
+                </ul>
+            @else
+                {{ $values['old'][$key] }}
+            @endif
+        </td>
         @endif
         <td>{{ $new }}</td>
     </tr>

--- a/resources/views/columns/activity_changes.blade.php
+++ b/resources/views/columns/activity_changes.blade.php
@@ -29,7 +29,17 @@ $old = isset($values['old']);
             @endif
         </td>
         @endif
-        <td class="{{ ($values['old'][$key] != $new) ? 'text-success' : '' }}">{{ $new }}</td>
+        <td class="{{ ($values['old'][$key] != $new) ? 'text-success' : '' }}">
+            @if (is_array($new))
+            <ul class="pl-3" style="list-style: circle">
+                @foreach ($new as $attribute => $value)
+                <li><strong>{{ $attribute }}</strong>: {{ $value }}</li>
+                @endforeach
+            </ul>
+            @else
+            {{ $new }}
+            @endif
+        </td>
     </tr>
     @endif
     @endforeach

--- a/resources/views/columns/activity_changes.blade.php
+++ b/resources/views/columns/activity_changes.blade.php
@@ -4,7 +4,7 @@ $values = $column['value'] ?? data_get($entry, $column['name']);
 $old = isset($values['old']);
 @endphp
 
-<table class="table table-sm" style="max-width: 480px">
+<table class="table table-sm table-bordered table-hover">
     <tr>
         <th>{{ ucfirst(__('backpack.activity-log::activity_log.key')) }}</th>
         @if($old)
@@ -17,9 +17,9 @@ $old = isset($values['old']);
     <tr>
         <td class="font-weight-bold">{{ str_replace('_', ' ', ucfirst(__($key))) }}</td>
         @if($old)
-        <td>
+        <td class="{{ ($values['old'][$key] != $new) ? 'text-danger' : '' }}">
             @if (is_array($values['old'][$key]))
-                <ul class="pl-1" style="list-style: circle">
+                <ul class="pl-3" style="list-style: circle">
                 @foreach ($values['old'][$key] as $attribute => $value)
                     <li><strong>{{ $attribute }}</strong>: {{ $value }}</li>
                 @endforeach
@@ -29,7 +29,7 @@ $old = isset($values['old']);
             @endif
         </td>
         @endif
-        <td>{{ $new }}</td>
+        <td class="{{ ($values['old'][$key] != $new) ? 'text-success' : '' }}">{{ $new }}</td>
     </tr>
     @endif
     @endforeach

--- a/src/Http/Controllers/ActivityLogCrudController.php
+++ b/src/Http/Controllers/ActivityLogCrudController.php
@@ -109,6 +109,8 @@ class ActivityLogCrudController extends CrudController
     {
         $this->setupListOperation();
 
+        CRUD::set('show.contentClass','col-md-12');
+
         CRUD::addColumn([
             'name' => 'causer_type',
             'label' => ucfirst(__('backpack.activity-log::activity_log.causer_model')),


### PR DESCRIPTION
Before this PR, if you had a column like `extras` that had changed... you'd get a big fat error because you can't convert array to string. After this PR, it splits up the array into a list:

<img width="1279" alt="CleanShot 2023-08-29 at 13 21 15@2x" src="https://github.com/Laravel-Backpack/activity-log/assets/1032474/99767d9e-0f75-4e21-a7f5-82a2112694a0">

It's not exactly pretty... but at least there's no error right?