### PR TITLE
Dont setup filters if Backpack/PRO is not available

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ How does it all work? Well:
 
 ![](https://user-images.githubusercontent.com/1032474/205863022-827f3248-a9f3-4d05-896f-5fa7a40227be.gif)
 
-**NOTE**: The filters are a [Backpack\PRO](https://backpackforlaravel.com/products/pro-for-one-project) feature. If you don't have that package the filters wont be available.
+**NOTE**: The filters are a [Backpack\PRO](https://backpackforlaravel.com/products/pro-for-one-project) feature. If you don't have that package the filters won't be available.
 ## Demo
 
 Try it right now, in [our online demo](https://demo.backpackforlaravel.com/admin/activity-log).  Edit some entities, and check the [activity logs](https://demo.backpackforlaravel.com/admin/activity-log).

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ How does it all work? Well:
 
 ![](https://user-images.githubusercontent.com/1032474/205863022-827f3248-a9f3-4d05-896f-5fa7a40227be.gif)
 
-
+**NOTE**: The filters are a [Backpack\PRO](https://backpackforlaravel.com/products/pro-for-one-project) feature. If you don't have that package the filters wont be available.
 ## Demo
 
 Try it right now, in [our online demo](https://demo.backpackforlaravel.com/admin/activity-log).  Edit some entities, and check the [activity logs](https://demo.backpackforlaravel.com/admin/activity-log).

--- a/src/Http/Controllers/ActivityLogCrudController.php
+++ b/src/Http/Controllers/ActivityLogCrudController.php
@@ -154,6 +154,10 @@ class ActivityLogCrudController extends CrudController
      */
     public function setupFilters()
     {
+        if(! backpack_pro()) {
+            return;
+        }
+        
         /**
          * Causer Model
          */


### PR DESCRIPTION
This avoids the error reported in: https://github.com/Laravel-Backpack/community-forum/discussions/748

When trying to use this package without PRO, it was throwing an error because it couldn't setup the filters. 

I think the filters should be seen as "sugar added" and not "mandatory" for this package, ence this PR. 

@promatik anything I am missing or can we merge this ? 

Cheers